### PR TITLE
Improvements for top-bar component

### DIFF
--- a/web/app/src/components/homepage/top-bar.vue
+++ b/web/app/src/components/homepage/top-bar.vue
@@ -23,15 +23,17 @@
 <style lang="scss" scoped>
 .top-bar-wrapper {
   height: 40px;
-  border-width: 1px;
-  border-style: solid;
-  border-image: linear-gradient(
+  background:linear-gradient(
     to right,
     rgb(252, 218, 159) 0%,
     rgb(255, 95, 56) 52%,
     rgb(192, 37, 51) 100%
-  );
-  border-image-slice: 1;
+  )
+  bottom
+  transparent    
+  no-repeat; 
+
+  background-size:100% 1px ;
   box-sizing: border-box;
   line-height: 40px;
 
@@ -45,9 +47,11 @@
   .rendez-vous-wrapper {
     justify-content: flex-start;
     flex-grow: 1;
+    font-weight: 900;
   }
   .links-wrapper {
     justify-content: flex-end;
+    font-weight: 500;
     ul {
       margin: 0;
       padding: 0;


### PR DESCRIPTION
- Workaround for unsupported border-bottom gradient
- Added font weights according to reference pictures

Before :
![image](https://user-images.githubusercontent.com/20010676/49754587-e843fe00-fccf-11e8-9b31-15e50952d3d4.png)

After : 
![image](https://user-images.githubusercontent.com/20010676/49754642-1295bb80-fcd0-11e8-9dea-262f9505db6c.png)

Reference : #8 