### PR TITLE
Feat #11 "Sessionize as backoffice"

### DIFF
--- a/web/app/src/App.vue
+++ b/web/app/src/App.vue
@@ -1,17 +1,28 @@
 <template>
   <div id="app">
-    <router-view/>
+    <router-view />
   </div>
 </template>
 
 <script>
+import { mapActions } from "vuex";
+
+import { FETCH_SESSIONIZE_DATA } from "@/store";
+
 export default {
   created() {
-    fetch(
-      "https://raw.githubusercontent.com/mscraftsman/devcon2019/master/web/app/package.json"
-    )
-      .then(response => response.json())
-      .then(data => console.log(data));
+    // * We can add other requests in the array as long as they can all be ran in parallel.
+    const promises = [this.FETCH_SESSIONIZE_DATA()];
+    promises.all(promises).then(this.handleDataFetched);
+  },
+
+  methods: {
+    ...mapActions(FETCH_SESSIONIZE_DATA),
+
+    handleDataFetched() {
+      // * This can be changed to something more useful when required.
+      console.log("Data fetched!");
+    }
   }
 };
 </script>

--- a/web/app/src/App.vue
+++ b/web/app/src/App.vue
@@ -13,11 +13,11 @@ export default {
   created() {
     // * We can add other requests in the array as long as they can all be ran in parallel.
     const promises = [this.FETCH_SESSIONIZE_DATA()];
-    promises.all(promises).then(this.handleDataFetched);
+    Promise.all(promises).then(this.handleDataFetched);
   },
 
   methods: {
-    ...mapActions(FETCH_SESSIONIZE_DATA),
+    ...mapActions([FETCH_SESSIONIZE_DATA]),
 
     handleDataFetched() {
       // * This can be changed to something more useful when required.

--- a/web/app/src/store.js
+++ b/web/app/src/store.js
@@ -3,8 +3,45 @@ import Vuex from "vuex";
 
 Vue.use(Vuex);
 
+const sessionizeURL = "https://sessionize.com/api/v2/351ijy5v/view/all";
+
+export const SET_SPEAKERS = "SET_SPEAKERS";
+export const SET_SPEAKERS = "SET_SPEAKERS";
+
+export const FETCH_SESSIONIZE_DATA = "FETCH_SESSIONIZE_DATA";
+
 export default new Vuex.Store({
-  state: {},
-  mutations: {},
-  actions: {}
+  state: {
+    speakers: [],
+    sessions: []
+  },
+  getters: {
+    getSpeakers: function(state) {
+      return state.speakers;
+    },
+    getSessions: function(state) {
+      return state.sessions;
+    }
+  },
+  mutations: {
+    [SET_SPEAKERS](state, speakers) {
+      state.speakers = speakers;
+    },
+    [SET_SESSIONS](state, sessions) {
+      state.sessions = sessions;
+    }
+  },
+  actions: {
+    [FETCH_SESSIONIZE_DATA]({ commit }) {
+      return fetch(sessionizeURL)
+        .then(response => response.json())
+        .then(({ speakers, sessions }) => {
+          commit(SET_SPEAKERS, speakers);
+          commit(SET_SESSIONS, sessions);
+        })
+        .catch(error => {
+          throw new Error("Error should be caught by Vue global error handler." + error);
+        });
+    }
+  }
 });

--- a/web/app/src/store.js
+++ b/web/app/src/store.js
@@ -6,7 +6,7 @@ Vue.use(Vuex);
 const sessionizeURL = "https://sessionize.com/api/v2/351ijy5v/view/all";
 
 export const SET_SPEAKERS = "SET_SPEAKERS";
-export const SET_SPEAKERS = "SET_SPEAKERS";
+export const SET_SESSIONS = "SET_SESSIONS";
 
 export const FETCH_SESSIONIZE_DATA = "FETCH_SESSIONIZE_DATA";
 
@@ -40,7 +40,9 @@ export default new Vuex.Store({
           commit(SET_SESSIONS, sessions);
         })
         .catch(error => {
-          throw new Error("Error should be caught by Vue global error handler." + error);
+          throw new Error(
+            "Error should be caught by Vue global error handler." + error
+          );
         });
     }
   }


### PR DESCRIPTION
Implements Issue #11 "Sessionize as backoffice". 




@MrSunshyne questions:

   [App.vue line 24](https://github.com/mscraftsman/devcon2019/compare/feat-%2311-sessionize-data?expand=1#diff-f79a7d4f83c74091ebe0968667f04354R24) anything useful I could add instead of a log?
   
[store.js line 6-11](https://github.com/mscraftsman/devcon2019/compare/feat-%2311-sessionize-data?expand=1#diff-853bedce0aa533162fab92396906c9d9R6) think we'd need to move those constants into separate files?  

[store.js line 43](https://github.com/mscraftsman/devcon2019/compare/feat-%2311-sessionize-data?expand=1#diff-853bedce0aa533162fab92396906c9d9R43) for the global error handler, I'm thinking of this: [(vue docs) Vue.config.errorHandler ![](https://upload.wikimedia.org/wikipedia/commons/6/64/Icon_External_Link.png)](https://vuejs.org/v2/api/#errorHandler)