### PR TITLE
wrap set scrollTop in if condition

### DIFF
--- a/web/app/src/views/PageSessions.vue
+++ b/web/app/src/views/PageSessions.vue
@@ -19,14 +19,14 @@
           <div
             class="tabs-panel-content"
             v-if="getDay(group.groupName) === active"
-            ref = "content"
+            ref="content"
             v-for="group in sessions"
             :key="group.groupId"
           >
             <div class="session-panes" v-for="session in group.sessions" :key="session.id">
               <router-link
                 class="session-row"
-                @click.native = "setScrollPosition()"
+                @click.native="setScrollPosition()"
                 :to="{ name: 'session',  params: { id: session.id }}"
               >
                 <div class="date-time">{{ time(session.startsAt) }} - {{ time(session.endsAt) }}</div>
@@ -47,31 +47,36 @@ import moment from "moment";
 export default {
   data() {
     return {
-      tabs: ["Thursday", "Friday", "Saturday"],
+      tabs: ["Thursday", "Friday", "Saturday"]
     };
   },
-  mounted(){
+  mounted() {
     // Keep Track of Scroll Position
-      this.$refs["content"][0].scrollTop = this.scrollPosition
-    },
+    if (this.sessions.length !== 0) {
+      this.$refs["content"][0].scrollTop = this.scrollPosition;
+    }
+  },
   methods: {
-    time: function (date) {
+    time: function(date) {
       // console.log()
       // return new Date(date).toDateString();
       return moment(date).format("LT");
     },
-    getDay: function (str) {
+    getDay: function(str) {
       console.log(str);
       return str.split(",")[0];
     },
-    setActive: function(str){
+    setActive: function(str) {
       // Keep Track of previous Page Sessions activity in current Session
-      this.$store.commit("SET_PAGESESSIONS_ACTIVE",str.split(",")[0]);
+      this.$store.commit("SET_PAGESESSIONS_ACTIVE", str.split(",")[0]);
     },
-    setScrollPosition: function(){
+    setScrollPosition: function() {
       // Keep Track of previous scroll position
-      this.$store.commit("SET_PAGESESSIONS_SCROLL_POSITION",this.$refs["content"][0].scrollTop)
-    },
+      this.$store.commit(
+        "SET_PAGESESSIONS_SCROLL_POSITION",
+        this.$refs["content"][0].scrollTop
+      );
+    }
   },
   computed: {
     ...mapGetters({


### PR DESCRIPTION
# Description

Looks like it's due to accessing a content element that is being v-for'd
[0] doesn't exist and should probably check for it first

Added and if condition to fix this

```js
 if (this.sessions.length !== 0) {
      this.$refs["content"][0].scrollTop = this.scrollPosition;
  }
```

Fixes #44 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Checked if `this.$refs["content"][0]` was causing warnings on different browsers and made sure that the above condition didn't break the expected behaviour ie preserve scroll in tabs

MacOS Mojave : Chrome, Firefox & Safari

Please describe the tests that you ran to verify your changes. 

Go on session page and see if there are any warnings and if the preserve scroll is working as expected