### PR TITLE
Center Footer on Mobile Devices

### DIFF
--- a/web/app/src/components/homepage/footer-section.vue
+++ b/web/app/src/components/homepage/footer-section.vue
@@ -72,7 +72,7 @@
 }
 
 @media screen and (max-width: $tablet) {
-  .link-wrapper {
+    .link-wrapper {
     margin-left: 0px;
     align-items: center;
     display: grid;
@@ -86,7 +86,7 @@
   }
   .footer-section-container {
     display: flex;
-    align-items: center;
+    justify-content: center;
   }
 }
 </style>


### PR DESCRIPTION
# Description

Before  
![cats](https://user-images.githubusercontent.com/20010676/50058254-17a2b100-018f-11e9-859c-54c419e6bbc7.jpg)

After
![cats](https://user-images.githubusercontent.com/20010676/50058264-26896380-018f-11e9-8f8a-7ff23e285bc3.jpg)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Looks good on Chrome across major Desktop & Mobile devices as well as on
Ｍｉｃｒｏｓｏｆｔ　Ｅｄｇｅ

References : #8 , #29