### PR TITLE
button-waw updated!

### DIFF
--- a/web/app/src/components/homepage/become-speaker.vue
+++ b/web/app/src/components/homepage/become-speaker.vue
@@ -10,7 +10,7 @@
       </div>
 
       <div class="button-center">
-        <button-waw :theme="'#97d0e1'" :size="'80px'" :link="'#'">Call for
+        <button-waw :theme="'#97d0e1'" :size="'70px'" :link="'#'">Call for
           Paper</button-waw>
       </div>
     </div>

--- a/web/app/src/components/homepage/intro-slider.vue
+++ b/web/app/src/components/homepage/intro-slider.vue
@@ -11,7 +11,7 @@
           <span class="mega-rainbow">greatest</span> conference in the air.
         </div>
         <div class="slide-item slide-button button">
-          <button-waw :theme="'#97d0e1'" :size="'80px'" :link="'#'">Register
+          <button-waw :theme="'#97d0e1'" :size="'70px'" :link="'#'">Register
             now</button-waw>
         </div>
       </slide>
@@ -27,7 +27,7 @@
           <span class="mega-rainbow">most woke</span> conference on ice.
         </div>
         <div class="slide-item slide-button button">
-          <button-waw :theme="'#97d0e1'" :size="'80px'" :link="'#'">Register
+          <button-waw :theme="'#97d0e1'" :size="'70px'" :link="'#'">Register
             now</button-waw>
         </div>
       </slide>
@@ -38,7 +38,7 @@
           <span class="mega-rainbow">Inclusive</span> are just the beginnings.
         </div>
         <div class="slide-item slide-button button">
-          <button-waw :theme="'#97d0e1'" :size="'80px'" :link="'#'">Register
+          <button-waw :theme="'#97d0e1'" :size="'70px'" :link="'#'">Register
             now</button-waw>
         </div>
       </slide>

--- a/web/app/src/components/homepage/sponsor-section.vue
+++ b/web/app/src/components/homepage/sponsor-section.vue
@@ -109,7 +109,7 @@
     <div class="button-center">
       <button-waw
         :theme="'#97d0e1'"
-        :size="'80px'"
+        :size="'70px'"
         :link="'https://github.com/mscraftsman/devcon2019/raw/master/assets/DevCon2019-SponsorshipProposal.pdf'"
       >
         Become

--- a/web/app/src/components/shared/button-waw.vue
+++ b/web/app/src/components/shared/button-waw.vue
@@ -40,6 +40,7 @@ export default {
   border-radius: 15px;
   border: 1px solid var(--theme);
   transition: 0.25s;
+  letter-spacing: 1px;
 
   &:hover {
     text-decoration: none;

--- a/web/app/src/components/shared/button-waw.vue
+++ b/web/app/src/components/shared/button-waw.vue
@@ -24,35 +24,27 @@ export default {
 };
 </script>
 
-
-
 <style lang="scss" scoped>
+
 .btn {
-  --theme: #ff4932;
+ --theme: #ff4932;
   color: var(--theme);
   cursor: pointer;
-  font-size: 16px;
-  font-weight: 400;
+  font-size: 18px;
+  font-weight: 600;
   position: relative;
   text-decoration: none;
   line-height: var(--size, 45px);
   text-transform: uppercase;
-  // width: 100%;
   text-align: center;
-
-  border: 0 solid;
-  box-shadow: inset 0 0 20px rgba(255, 255, 255, 0);
-  outline: 1px solid;
-  outline-color: var(--theme);
-  outline-offset: 0px;
-  // border-radius: 5px;
-  text-shadow: none;
-  transition: all 1250ms cubic-bezier(0.19, 1, 0.22, 1);
+  border-radius: 15px;
+  border: 1px solid var(--theme);
+  transition: 0.25s;
 
   &:hover {
     text-decoration: none;
   }
-  padding: 0 20px;
+  padding: 0px 60px;
 
   a,
   a span {
@@ -60,7 +52,6 @@ export default {
   }
 
   &.effect-hover {
-    // border: 1px solid var(--theme);
     overflow: hidden;
     position: relative;
 
@@ -93,15 +84,17 @@ export default {
   /////////////////////////////
   // Click
   ///////////////////////////
-
+ 
   &.click:active,
-  &.click:focus {
-    border: 1px solid;
-    box-shadow: inset 0 0 20px rgba(255, 255, 255, 0.5),
-      0 0 20px rgba(255, 255, 255, 0.2);
-    outline-color: rgba(255, 255, 255, 0);
-    outline-offset: 15px;
-    text-shadow: 1px 1px 2px #427388;
+  &.click:focus{
+
+  animation: pulse 0.3s;
+  box-shadow: 0 0 0 1em rgba(black,0);
+
+  @keyframes pulse {
+  0% { box-shadow: 0 0 0 0 var(--theme); }
+  }
+  
   }
 }
 </style>


### PR DESCRIPTION
# Description

Ditched CSS `outline` as it does not support any form of `borner-radius`. Previous `outline` based animation also cause some unnecessary displacement & repaint of neighboring components, which hinders  performance and my ocd.

A comparable `box-shadow` based animation implemented, along with some changes to button size, padding & font weight to match mockup.

**Size passed to `button-waw` component is now 70px instead of 80px, improves the button proportions.**

## Before
![ezgif-2-f49ca5953021](https://user-images.githubusercontent.com/20010676/50735744-ff8de280-11cc-11e9-8011-1fa94b6bf575.gif)

![ezgif-2-59a8fa3d5712](https://user-images.githubusercontent.com/20010676/50735825-36b0c380-11ce-11e9-9d94-e6b65fbac492.gif)

## PSD Mockup for reference

![cats](https://user-images.githubusercontent.com/20010676/50735949-ac695f00-11cf-11e9-96e3-7c3ce18af26f.jpg)



## After
![ezgif-2-19e37ff32c3a](https://user-images.githubusercontent.com/20010676/50735730-d1100780-11cc-11e9-869b-e6a02f284233.gif)

![ezgif-2-aadc21c5029c](https://user-images.githubusercontent.com/20010676/50735887-f4d44d00-11ce-11e9-879b-5a67cb5a94ca.gif)

# How Has This Been Tested?

Looks good on Chrome across major Desktop & Mobile devices as well as on
Ｍｉｃｒｏｓｏｆｔ　Ｅｄｇｅ, **only on homepage, found `button-waw`s only there**