### PR TITLE
Revert "text updated for pastEvent"

### DIFF
--- a/web/app/src/views/PagePastEvents.vue
+++ b/web/app/src/views/PagePastEvents.vue
@@ -26,7 +26,7 @@ export default {
     return {
       past_events: [
         {
-          title: "global hello azure bootcamps",
+          title: "global azure bootcamps",
           year: "25 April 2015",
           image: "",
           logo: "",


### PR DESCRIPTION
Reverts mscraftsman/devcon2019#67

The event's name back in 2015 was "Global Windows Azure Bootcamp" or short GWAB.