### PR TITLE
Center devcon stats on Homepage 🧙‍♂️

### DIFF
--- a/web/app/src/components/homepage/devcon-stats.vue
+++ b/web/app/src/components/homepage/devcon-stats.vue
@@ -37,9 +37,9 @@ export default {
 }
 .devcon-stats-container {
   display: grid;
-  // justify-content: space-around;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   grid-row-gap: 100px;
+  justify-items:center;
 
   .stat-wrapper {
     position: relative;


### PR DESCRIPTION
# Description

Center devcon-stats on homepage.

## Before

![cars](https://user-images.githubusercontent.com/20010676/52704737-b5054000-2f9a-11e9-942a-4be525c770fb.jpg)

## After

![cars](https://user-images.githubusercontent.com/20010676/52704679-8dae7300-2f9a-11e9-8da9-6fe1bbf51a15.jpg)

# How Has This Been Tested?

Looks good on Chrome across major Desktop & Mobile devices as well as on
Ｍｉｃｒｏｓｏｆｔ　Ｅｄｇｅ


