### PR TITLE
Center Featured Speakers on homepage for mobile & (small) tablet 🧙‍♂️

### DIFF
--- a/web/app/src/components/homepage/featured-speakers.vue
+++ b/web/app/src/components/homepage/featured-speakers.vue
@@ -44,4 +44,13 @@ h2 {
   padding-top: $gutter * 2;
   padding-bottom: $gutter * 2;
 }
+
+@media screen and (max-width: $tablet) {
+  
+  .featured-speakers-container {
+  
+    justify-items: center;
+  }
+
+}
 </style>


### PR DESCRIPTION
# Description

Centering stuff in grids, as usual.

## Before 
![bef-horz](https://user-images.githubusercontent.com/20010676/53818146-10669480-3f81-11e9-8673-9f179ab1ec60.jpg)

## After
![aff-horz](https://user-images.githubusercontent.com/20010676/53818184-1f4d4700-3f81-11e9-94cb-c606c4b7d20a.jpg)

- [x] Petit fix, mais puissant

# How Has This Been Tested?
Looks good on Chrome across major Desktop & Mobile 