### PR TITLE
tiny typo in social stripe footer

### DIFF
--- a/web/app/src/components/homepage/social-stripe.vue
+++ b/web/app/src/components/homepage/social-stripe.vue
@@ -5,7 +5,7 @@
         <LogoSvg />
       </div>
       <div class="text-wrapper">
-        <p>Mauritius Software Crafmanship Community</p>
+        <p>Mauritius Software Craftsmanship Community</p>
       </div>
       <div class="icon-wrapper">
         <!-- Meetup -->


### PR DESCRIPTION
# Description

Typo in social stripe footer; should be `Craftsmanship` instead of `Crafmanship`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

